### PR TITLE
Do not escape single quotes for the query

### DIFF
--- a/deepl.sh
+++ b/deepl.sh
@@ -58,8 +58,7 @@ fi
 query="$(echo "$query" | sed 's/.$//')"
 # shellcheck disable=SC2001
 query="$(echo "$query" | sed 's/\"/\\\"/g')"
-# shellcheck disable=SC2001
-query="$(echo "$query" | sed "s/'/\\\'/g")"
+
 data='{"jsonrpc":"2.0","method": "LMT_handle_jobs","params":{"jobs":[{"kind":"default","raw_en_sentence":"'"$query"'","raw_en_context_before":[],"raw_en_context_after":[],"quality":"fast"}],"lang":{"user_preferred_langs":["EN","DE"],"source_lang_user_selected":"auto","target_lang":"'"${LANGUAGE:-EN}"'"},"priority":-1,"timestamp":1557063997314},"id":79120002}'
 HEADER=(
   --compressed


### PR DESCRIPTION
### Issue
 
Trying to translate any scentence that includes a single quote `'` will cause DeepL to throw a Parse error. 

### Reproducing the issue

```bash 
./deepl.sh -l JA "How's"

{"items": [{"uid": null,"arg": "Error: Parse error","valid": "yes","autocomplete": "autocomplete","title": "Error: Parse error"}]}
```

### Possible cause of this issue

This line https://github.com/AlexanderWillner/deepl-alfred-workflow2/blob/master/deepl.sh#L62 escapses single quotes and replaces it with `\'`. That seems to be causing a confusion to DeepL. 

### After the fix

```bash 
./deepl.sh -l JA "How's."
{
  "items": [
    {
      "uid": null,
      "arg": "どうですか？",
      "valid": "yes",
      "autocomplete": "autocomplete",
      "title": "どうですか？"
    },
    {
      "uid": null,
      "arg": "どうだ？",
      "valid": "yes",
      "autocomplete": "autocomplete",
      "title": "どうだ？"
    },
    {
      "uid": null,
      "arg": "どうなんですか？",
      "valid": "yes",
      "autocomplete": "autocomplete",
      "title": "どうなんですか？"
    },
    {
      "uid": null,
      "arg": "どうなの？",
      "valid": "yes",
      "autocomplete": "autocomplete",
      "title": "どうなの？"
    }
  ]
}
```