### PR TITLE
Make dll Argument Optional

### DIFF
--- a/info5.plist
+++ b/info5.plist
@@ -391,7 +391,7 @@
 				<key>argumenttrimmode</key>
 				<integer>0</integer>
 				<key>argumenttype</key>
-				<integer>0</integer>
+				<integer>1</integer>
 				<key>escaping</key>
 				<integer>102</integer>
 				<key>keyword</key>


### PR DESCRIPTION
`dll` should be Argument Optional, so that results show up immediately.